### PR TITLE
Promote plugin to Eliza app: manifest + routes + viewer + ecosystem service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@elizaos/core": "^1.0.0"
+        "@elizaos/core": "^2.0.0-alpha.173"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -20,6 +20,175 @@
         "node": ">=22"
       }
     },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.71",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
+      "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "2.0.82",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.82.tgz",
+      "integrity": "sha512-vtoCSEBGPcxzChI3eqe9C9AJSlc/WUZp92tzpOqVd4B6Tnu4583S+qR7TknB0tPta15TEoOIkK0ENW6D/DgRJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.23",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
+      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.23.tgz",
+      "integrity": "sha512-60GYsRj5wIJQRcq5YwYJq4KhwLeStceXEJiZdecP1miiH+6FMmrnc7lZDOJoQ6m9lrudEb+uI4LEwddLz5+rPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.64",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.64.tgz",
+      "integrity": "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.32.1.tgz",
+      "integrity": "sha512-U9JwTrDvdQ9iWuABVsMLj8nJVwAyQz6QXvgLsVhryhCEPkLsbcP/MXxm+jYcAwLoV8ESbaTTjnD4kuAFa+Hyjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
+      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
@@ -27,23 +196,88 @@
       "license": "MIT"
     },
     "node_modules/@elizaos/core": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@elizaos/core/-/core-1.7.2.tgz",
-      "integrity": "sha512-NUw+YIXTejCCB07jevJ6cTbd/FKTqVoPwDrMMuBcjHeM+9UlQKFadDJooWEUREf37WS4KBegwLUOnr9H9CXpcw==",
+      "version": "2.0.0-alpha.173",
+      "resolved": "https://registry.npmjs.org/@elizaos/core/-/core-2.0.0-alpha.173.tgz",
+      "integrity": "sha512-rjeit5uyfA4TKuXJMciz+lhden6vOjaJ7kgwNYxccGF9lcd2MiuYorWbcOKhJ2ijI1sr9739p7Q15nYT9Mn/yw==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/core": "^1.0.0",
-        "@langchain/textsplitters": "^1.0.0",
+        "@ai-sdk/anthropic": "^3.0.13",
+        "@ai-sdk/google": "^3.0.8",
+        "@ai-sdk/openai": "^3.0.9",
+        "@anthropic-ai/sdk": "^0.32.1",
+        "@bufbuild/protobuf": "^2.11.0",
+        "@langchain/core": "^1.1.12",
+        "@langchain/textsplitters": "^1.0.1",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/hashes": "^1.8.0",
+        "@openrouter/ai-sdk-provider": "^1.2.0",
+        "@toon-format/toon": "^2.1.0",
         "adze": "^2.2.5",
-        "crypto-browserify": "^3.12.0",
+        "ai": "^6.0.30",
+        "coding-agent-adapters": "0.16.3",
+        "dedent": "^1.7.1",
         "dotenv": "^17.2.3",
+        "drizzle-orm": "^0.45.1",
         "fast-redact": "^3.5.0",
+        "file-type": "^21.3.0",
+        "fs-extra": "^11.3.2",
+        "git-workspace-service": "0.4.5",
         "glob": "^13.0.0",
         "handlebars": "^4.7.8",
-        "pdfjs-dist": "^5.2.133",
+        "json5": "^2.2.3",
+        "mammoth": "^1.9.0",
+        "markdown-it": "^14.1.0",
+        "pdfjs-dist": "^5.4.530",
+        "undici": "^7.0.0",
         "unique-names-generator": "^4.7.1",
+        "unpdf": "^1.4.0",
         "uuid": "^13.0.0",
-        "zod": "^4.3.5"
+        "yaml": "^2.7.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@elizaos/core/node_modules/@ai-sdk/gateway": {
+      "version": "3.0.104",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
+      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@elizaos/core/node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@elizaos/core/node_modules/ai": {
+      "version": "6.0.168",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
+      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.104",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -112,36 +346,6 @@
       },
       "peerDependencies": {
         "@langchain/core": "^1.0.0"
-      }
-    },
-    "node_modules/@napi-rs/canvas": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.99.tgz",
-      "integrity": "sha512-zN4eQlK3eBf7aJBcTHZilpBH3tDekBzPMIWC8r0s94Ecl73XfOyFi4w7yKFMRVUT0lvNQjtOL8YSrwqQj6mZFg==",
-      "license": "MIT",
-      "optional": true,
-      "workspaces": [
-        "e2e/*"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.99",
-        "@napi-rs/canvas-darwin-arm64": "0.1.99",
-        "@napi-rs/canvas-darwin-x64": "0.1.99",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.99",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.99",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.99",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.99",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.99",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.99",
-        "@napi-rs/canvas-win32-arm64-msvc": "0.1.99",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.99"
       }
     },
     "node_modules/@napi-rs/canvas-android-arm64": {
@@ -383,6 +587,315 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@octokit/auth-app": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.4.tgz",
+      "integrity": "sha512-QkXkSOHZK4dA5oUqY5Dk3S+5pN2s1igPjEASNQV8/vgJgW034fQWR16u7VsNOK/EljA00eyjYF5mWNxWKWhHRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^7.1.0",
+        "@octokit/auth-oauth-user": "^4.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.3.1",
+        "lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
+        "universal-github-app-jwt": "^1.1.2",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-7.1.0.tgz",
+      "integrity": "sha512-w+SyJN/b0l/HEb4EOPRudo7uUOSW51jcK1jwLa+4r7PA8FPFpoxEnHBHMITqCsc/3Vo2qqFjgQfz/xUUvsSQnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^6.1.0",
+        "@octokit/auth-oauth-user": "^4.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/types": "^13.0.0",
+        "@types/btoa-lite": "^1.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-6.1.0.tgz",
+      "integrity": "sha512-FNQ7cb8kASufd6Ej4gnJ3f1QB5vJitkoV1O0/g6e6lUsQ7+VsSNRHRmFScN2tV4IgKA12frrr/cegUs0t+0/Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-methods": "^4.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-4.1.0.tgz",
+      "integrity": "sha512-FrEp8mtFuS/BrJyjpur+4GARteUCrPeR/tZJzD8YourzoVhRics7u7we/aDcKv+yywRNwNi/P4fRi631rG/OyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^6.1.0",
+        "@octokit/oauth-methods": "^4.1.0",
+        "@octokit/request": "^8.3.1",
+        "@octokit/types": "^13.0.0",
+        "btoa-lite": "^1.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz",
+      "integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-4.1.0.tgz",
+      "integrity": "sha512-4tuKnCRecJ6CG6gr0XcEXdZtkTDbfbnD5oaHBmLERTjTMZNi2CbfEHZxPU41xXLDG4DfKf+sonu00zvKI9NSbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^6.0.2",
+        "@octokit/request": "^8.3.1",
+        "@octokit/request-error": "^5.1.0",
+        "@octokit/types": "^13.0.0",
+        "btoa-lite": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.4.4-cjs.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz",
+      "integrity": "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.7.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+      "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.3.2-cjs.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz",
+      "integrity": "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.8.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^5"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.2.tgz",
+      "integrity": "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^5.0.2",
+        "@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@openrouter/ai-sdk-provider": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-1.5.4.tgz",
+      "integrity": "sha512-xrSQPUIH8n9zuyYZR0XK7Ba0h2KsjJcMkxnwaYfmv13pKs3sDkjPzVPPhlhzqBGddHb5cFEwJ9VFuFeDcxCDSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openrouter/sdk": "^0.1.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ai": "^5.0.0",
+        "zod": "^3.24.1 || ^v4"
+      }
+    },
+    "node_modules/@openrouter/sdk": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.1.27.tgz",
+      "integrity": "sha512-RH//L10bSmc81q25zAZudiI4kNkLgxF2E+WU42vghp3N6TEvZ6F0jK7uT3tOxkEn91gzmMw9YVmDENy7SJsajQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.124.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
@@ -392,6 +905,12 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
@@ -616,6 +1135,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
@@ -663,6 +1205,35 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@toon-format/toon": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.1.0.tgz",
+      "integrity": "sha512-JwWptdF5eOA0HaQxbKAzkpQtR4wSWTEfDlEy/y3/4okmOAX1qwnpLZMmtEWr+ncAhTTY1raCKH0kteHhSXnQqg==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -673,6 +1244,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/btoa-lite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
+      "integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==",
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -699,15 +1276,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -715,6 +1316,15 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.4",
@@ -829,6 +1439,36 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/adapter-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/adapter-types/-/adapter-types-0.2.0.tgz",
+      "integrity": "sha512-T6YjdynGF9u1+D+DnqjsGmyW/dkq+kVRpz/wgVGcK2EHBAz9ETCX9Kz9ZHZdqyd0B2s/YJ0euGHiwhOFoGe0NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/adze": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/adze/-/adze-2.3.0.tgz",
@@ -840,6 +1480,65 @@
       },
       "engines": {
         "node": ">=18.19.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "5.0.179",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.179.tgz",
+      "integrity": "sha512-tuq/r2FH/pBuY3jo0yHF3UglDV73WONGLhW80DuwgO6w0ftPIqRsAm5p9cE3Bu4LfEuCkMXpiUG/pQRzqKRRaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "2.0.82",
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
+      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.23.tgz",
+      "integrity": "sha512-60GYsRj5wIJQRcq5YwYJq4KhwLeStceXEJiZdecP1miiH+6FMmrnc7lZDOJoQ6m9lrudEb+uI4LEwddLz5+rPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ansi-styles": {
@@ -854,22 +1553,14 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/asn1.js": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "license": "MIT",
       "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "sprintf-js": "~1.0.2"
       }
-    },
-    "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -881,19 +1572,19 @@
         "node": ">=12"
       }
     },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
       "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -925,10 +1616,16 @@
       ],
       "license": "MIT"
     },
-    "node_modules/bn.js": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
-      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -943,106 +1640,17 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+    "node_modules/btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
       "license": "MIT"
     },
-    "node_modules/browserify-aes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/browserify-cipher": {
+    "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-      "license": "MIT",
-      "dependencies": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
-      }
-    },
-    "node_modules/browserify-des": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/browserify-rsa": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
-      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^5.2.1",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/browserify-sign": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
-      "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
-      "license": "ISC",
-      "dependencies": {
-        "bn.js": "^5.2.2",
-        "browserify-rsa": "^4.1.1",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "elliptic": "^6.6.1",
-        "inherits": "^2.0.4",
-        "parse-asn1": "^5.1.9",
-        "readable-stream": "^2.3.8",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/buffer-xor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-      "license": "MIT"
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -1055,22 +1663,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -1095,18 +1687,37 @@
         "node": ">=18"
       }
     },
-    "node_modules/cipher-base": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
-      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+    "node_modules/coding-agent-adapters": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/coding-agent-adapters/-/coding-agent-adapters-0.16.3.tgz",
+      "integrity": "sha512-eY2fiJ95sIYl2PUok7EP2XREQ+Mjpz88itv0rJV9ChS0g94PwfqDE6Vm1/qhBqOCt6CIE6HD0FMHzZlM+51nig==",
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.2"
+        "adapter-types": "^0.2.0",
+        "pino": "^9.6.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "agent-adapter-monitor": "^0.3.0"
+      },
+      "peerDependenciesMeta": {
+        "agent-adapter-monitor": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/convert-source-map": {
@@ -1122,73 +1733,21 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
-    "node_modules/create-ecdh": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
-      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.5.3"
-      }
-    },
-    "node_modules/create-ecdh/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
-    },
-    "node_modules/create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "node_modules/create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
-    "node_modules/crypto-browserify": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
-      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
-      "license": "MIT",
-      "dependencies": {
-        "browserify-cipher": "^1.0.1",
-        "browserify-sign": "^4.2.3",
-        "create-ecdh": "^4.0.4",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "diffie-hellman": "^5.0.3",
-        "hash-base": "~3.0.4",
-        "inherits": "^2.0.4",
-        "pbkdf2": "^3.1.2",
-        "public-encrypt": "^4.0.3",
-        "randombytes": "^2.1.0",
-        "randomfill": "^1.0.4"
+        "ms": "^2.1.3"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=6.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decamelize": {
@@ -1200,32 +1759,34 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
       },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
-    "node_modules/des.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
-      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+      "engines": {
+        "node": ">=0.4.0"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "license": "ISC"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1237,22 +1798,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/diffie-hellman": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
-      }
-    },
-    "node_modules/diffie-hellman/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -1264,6 +1814,140 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -1280,26 +1964,26 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "license": "MIT",
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -1338,6 +2022,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1348,20 +2047,28 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
-    "node_modules/evp_bytestokey": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
-      "dependencies": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expect-type": {
@@ -1401,19 +2108,71 @@
         }
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
       "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.2.7"
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
       },
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=20"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fsevents": {
@@ -1477,6 +2236,32 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/git-workspace-service": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/git-workspace-service/-/git-workspace-service-0.4.5.tgz",
+      "integrity": "sha512-T5mMXDku9s/Gz3yus/CudzqUg2KbaGvF4Y4lgDYZYDGbeFiGWYuJLzVexWQMaiOuctw5XKvRKQYLyB2nwXsMSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-app": "^6.0.0",
+        "@octokit/rest": "^20.0.0",
+        "pino": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@octokit/auth-app": ">=6.0.0",
+        "@octokit/rest": ">=20.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@octokit/auth-app": {
+          "optional": true
+        },
+        "@octokit/rest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -1506,6 +2291,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -1525,18 +2316,6 @@
       },
       "optionalDependencies": {
         "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -1566,29 +2345,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hash-base": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
-      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -1601,49 +2357,46 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "license": "MIT",
       "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "ms": "^2.0.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -1658,6 +2411,91 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.5.1"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/langsmith": {
@@ -1705,6 +2543,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -1968,6 +2815,68 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
@@ -1987,6 +2896,53 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mammoth": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+      "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1996,47 +2952,32 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "node_modules/miller-rabin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
       "dependencies": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "mime-db": "1.52.0"
       },
-      "bin": {
-        "miller-rabin": "bin/miller-rabin"
+      "engines": {
+        "node": ">= 0.6"
       }
-    },
-    "node_modules/miller-rabin/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "license": "ISC"
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
@@ -2070,6 +3011,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/mustache": {
       "version": "4.2.0",
@@ -2105,6 +3052,46 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-readable-to-web-readable-stream": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
@@ -2122,6 +3109,30 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
@@ -2160,20 +3171,19 @@
         "node": ">=8"
       }
     },
-    "node_modules/parse-asn1": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
-      "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
-      "license": "ISC",
-      "dependencies": {
-        "asn1.js": "^4.10.1",
-        "browserify-aes": "^1.2.0",
-        "evp_bytestokey": "^1.0.3",
-        "pbkdf2": "^3.1.5",
-        "safe-buffer": "^5.2.1"
-      },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-scurry": {
@@ -2198,23 +3208,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pbkdf2": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
-      "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ripemd160": "^2.0.3",
-        "safe-buffer": "^5.2.1",
-        "sha.js": "^2.4.12",
-        "to-buffer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/pdfjs-dist": {
       "version": "5.6.205",
@@ -2249,14 +3242,42 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
       }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.10",
@@ -2293,44 +3314,36 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
-    "node_modules/public-encrypt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/public-encrypt/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
+      "engines": {
+        "node": ">=6"
       }
     },
-    "node_modules/randomfill": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-      "license": "MIT",
-      "dependencies": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
-      }
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
@@ -2347,38 +3360,13 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/ripemd160": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
-      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
       "license": "MIT",
-      "dependencies": {
-        "hash-base": "^3.1.2",
-        "inherits": "^2.0.4"
-      },
       "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/ripemd160/node_modules/hash-base": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
-      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^2.3.8",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/rolldown": {
@@ -2416,61 +3404,37 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=10"
       }
     },
-    "node_modules/sha.js": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
-      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
-      "license": "(MIT AND BSD-3-Clause)",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.0"
-      },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
       "bin": {
-        "sha.js": "bin.js"
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -2478,6 +3442,15 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -2497,6 +3470,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -2521,11 +3509,30 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2571,24 +3578,28 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/to-buffer": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
-      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
       "license": "MIT",
       "dependencies": {
-        "isarray": "^2.0.5",
-        "safe-buffer": "^5.2.1",
-        "typed-array-buffer": "^1.0.3"
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
       },
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/to-buffer/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
     "node_modules/tslib": {
@@ -2598,20 +3609,6 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
-    },
-    "node_modules/typed-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -2627,6 +3624,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -2640,11 +3643,37 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unique-names-generator": {
@@ -2654,6 +3683,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.2.0.tgz",
+      "integrity": "sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.0",
+        "jsonwebtoken": "^9.0.2"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "license": "ISC"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpdf": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.0.tgz",
+      "integrity": "sha512-DsjbuDe6PDbZzGvAP40QQp0xskrXP3Tm3fd/FLkGObL00Icr7cc28QgrPHYg+6B1lMWydgXwDXauIv5CGyXudA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.69"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {
@@ -2844,25 +3912,29 @@
         }
       }
     },
-    "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
       "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/why-is-node-running": {
@@ -2888,11 +3960,42 @@
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "license": "MIT"
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -26,16 +26,44 @@
   },
   "keywords": [
     "elizaos-plugin",
+    "elizaos-app",
     "milady-plugin",
     "solana",
     "ratibot",
     "research",
     "defi"
   ],
+  "elizaos": {
+    "kind": "app",
+    "app": {
+      "displayName": "Ratibot Research",
+      "category": "research",
+      "launchType": "embed",
+      "launchUrl": null,
+      "capabilities": [
+        "research",
+        "solana",
+        "feed",
+        "ecosystem"
+      ],
+      "runtimePlugin": "@cenetex/plugin-ratibot-research",
+      "viewer": {
+        "url": "/api/apps/ratibot-research/viewer",
+        "sandbox": "allow-scripts allow-same-origin allow-popups allow-forms"
+      },
+      "session": {
+        "mode": "viewer",
+        "features": [
+          "commands",
+          "telemetry"
+        ]
+      }
+    }
+  },
   "author": "Cenetex Inc.",
   "license": "MIT",
   "dependencies": {
-    "@elizaos/core": "^1.0.0"
+    "@elizaos/core": "^2.0.0-alpha.173"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/src/__tests__/ratibot-ecosystem.test.ts
+++ b/src/__tests__/ratibot-ecosystem.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { RatibotEcosystem } from "../services/ratibot-ecosystem.js";
+import type { EcosystemPayload } from "../types.js";
+
+function okJson(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const SAMPLE: EcosystemPayload = {
+  home_tokens: ["RATI"],
+  home_token: "RATI",
+  home_holders: 700,
+  scanned_at: "2026-04-20T00:00:00Z",
+  cached_at: "2026-04-20T01:00:00Z",
+  tokens: [
+    {
+      address: "ADDR1",
+      symbol: "USDC",
+      name: "USD Coin",
+      overlap_percent: 10,
+      overlap_holders: 4,
+      price_usd: 1,
+      liquidity_usd: 500_000_000,
+      flow_direction: "accumulating",
+      flow_score: 0.5,
+      rank: 1,
+    },
+  ],
+};
+
+describe("RatibotEcosystem", () => {
+  it("getEcosystem fetches once and caches within TTL", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(okJson(SAMPLE));
+    const svc = new RatibotEcosystem(undefined, {
+      apiBase: "https://cdn.test",
+      ttlMs: 60_000,
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    const a = await svc.getEcosystem();
+    const b = await svc.getEcosystem();
+    expect(a).toBe(b);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://cdn.test/cache/ecosystem.json",
+      expect.objectContaining({ headers: { Accept: "application/json" } }),
+    );
+  });
+
+  it("refresh forces a fresh fetch", async () => {
+    const fetchImpl = vi.fn().mockImplementation(async () => okJson(SAMPLE));
+    const svc = new RatibotEcosystem(undefined, {
+      apiBase: "https://cdn.test",
+      ttlMs: 60_000,
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    await svc.getEcosystem();
+    await svc.refresh();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("collapses concurrent in-flight refreshes into one request", async () => {
+    let resolveFetch!: (r: Response) => void;
+    const fetchImpl = vi.fn().mockImplementation(
+      () => new Promise<Response>((resolve) => (resolveFetch = resolve)),
+    );
+    const svc = new RatibotEcosystem(undefined, {
+      apiBase: "https://cdn.test",
+      ttlMs: 60_000,
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    const p1 = svc.getEcosystem();
+    const p2 = svc.refresh();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    resolveFetch(okJson(SAMPLE));
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toBe(r2);
+  });
+
+  it("normalizes a sparse payload safely", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(okJson({}));
+    const svc = new RatibotEcosystem(undefined, {
+      apiBase: "https://cdn.test",
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    const got = await svc.getEcosystem();
+    expect(got.home_tokens).toEqual([]);
+    expect(got.tokens).toEqual([]);
+    expect(got.home_holders).toBe(0);
+  });
+
+  it("throws on non-JSON response (CDN SPA fallback case)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response("<html>spa</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+    const svc = new RatibotEcosystem(undefined, {
+      apiBase: "https://cdn.test",
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    await expect(svc.getEcosystem()).rejects.toThrow(/not published yet/);
+  });
+});

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { handleAppRoutes, type RouteContext } from "../routes.js";
+import { RatibotEcosystem } from "../services/ratibot-ecosystem.js";
+import { RatibotReportFeed } from "../services/ratibot-feed.js";
+import type { EcosystemPayload, ReportIndexEntry } from "../types.js";
+
+const REPORTS: ReportIndexEntry[] = [
+  {
+    date: "2026-04-19",
+    type: "weekly",
+    title: "Weekly Report — 2026-04-19",
+    url: "/reports/weekly/2026-04-19.pdf",
+    size_bytes: 389_389,
+    generated_at: "2026-04-19T23:18:12Z",
+  },
+  {
+    date: "2026-04-15",
+    type: "spotlight",
+    title: "Token Spotlight: USDC",
+    url: "/reports/spotlight/2026-04-15-usdc.pdf",
+    size_bytes: 120_000,
+    generated_at: "2026-04-15T10:00:00Z",
+  },
+];
+
+const ECOSYSTEM: EcosystemPayload = {
+  home_tokens: ["RATI"],
+  home_token: "RATI-MINT",
+  home_holders: 700,
+  scanned_at: "2026-04-20T00:00:00Z",
+  cached_at: "2026-04-20T01:00:00Z",
+  tokens: [
+    {
+      address: "USDC-ADDR",
+      symbol: "USDC",
+      name: "USD Coin",
+      overlap_percent: 10,
+      overlap_holders: 4,
+      price_usd: 1,
+      liquidity_usd: 500_000_000,
+      flow_direction: "accumulating",
+      flow_score: 0.5,
+      rank: 1,
+    },
+    {
+      address: "PENGU-ADDR",
+      symbol: "PENGU",
+      name: "Pudgy Penguins",
+      overlap_percent: 7.5,
+      overlap_holders: 3,
+      price_usd: 0.0075,
+      liquidity_usd: 2_454_524,
+      flow_direction: "new",
+      flow_score: 0.5,
+      rank: 2,
+    },
+  ],
+};
+
+function mkRes() {
+  const headers: Record<string, string> = {};
+  const removed: string[] = [];
+  let body: string | undefined;
+  let statusCode = 0;
+  return {
+    res: {
+      get statusCode() { return statusCode; },
+      set statusCode(v: number) { statusCode = v; },
+      setHeader(name: string, value: string) { headers[name.toLowerCase()] = value; },
+      getHeader(name: string) { return headers[name.toLowerCase()]; },
+      removeHeader(name: string) {
+        removed.push(name.toLowerCase());
+        delete headers[name.toLowerCase()];
+      },
+      end(b?: string) { body = b; },
+    },
+    headers,
+    removed,
+    get body() { return body; },
+    get status() { return statusCode; },
+  };
+}
+
+function mkCtx(method: string, pathname: string, runtime: unknown, res: any, bodyJson?: unknown): RouteContext {
+  return {
+    method,
+    pathname,
+    url: new URL(`http://localhost${pathname}`),
+    runtime,
+    res,
+    error: vi.fn((r: any, message: string, status?: number) => {
+      r.statusCode = status ?? 500;
+      r.end(JSON.stringify({ error: message }));
+    }),
+    json: vi.fn((r: any, data: unknown, status?: number) => {
+      r.statusCode = status ?? 200;
+      r.setHeader("Content-Type", "application/json");
+      r.end(JSON.stringify(data));
+    }),
+    readJsonBody: vi.fn(async () => bodyJson ?? {}),
+  };
+}
+
+interface FetchMockOpts {
+  reports?: ReportIndexEntry[] | "throw";
+  ecosystem?: EcosystemPayload | "throw";
+}
+
+function mockGlobalFetch(opts: FetchMockOpts) {
+  const fetchImpl = vi.fn(async (input: any) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (url.endsWith("/reports/index.json")) {
+      if (opts.reports === "throw") throw new Error("reports network down");
+      return new Response(JSON.stringify({ reports: opts.reports ?? REPORTS }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.endsWith("/cache/ecosystem.json")) {
+      if (opts.ecosystem === "throw") throw new Error("ecosystem network down");
+      return new Response(JSON.stringify(opts.ecosystem ?? ECOSYSTEM), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response("not found", { status: 404 });
+  });
+  vi.stubGlobal("fetch", fetchImpl);
+  return fetchImpl;
+}
+
+function mkRuntime(opts: { withEcosystemService?: boolean } = {}) {
+  let ecoService: RatibotEcosystem | null = null;
+  if (opts.withEcosystemService) {
+    ecoService = new RatibotEcosystem(undefined, {
+      apiBase: "https://cdn.test",
+      fetch: (async () =>
+        new Response(JSON.stringify(ECOSYSTEM), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })) as any,
+    });
+  }
+  return {
+    agentId: "agent-007",
+    character: { name: "Kyro" },
+    getSetting: (k: string) => (k === "RATIBOT_API_BASE" ? "https://cdn.test" : undefined),
+    getService: <T>(type: string) => {
+      if (type === RatibotEcosystem.serviceType) return ecoService as unknown as T;
+      if (type === RatibotReportFeed.serviceType) return null as unknown as T;
+      return null as unknown as T;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("handleAppRoutes — viewer", () => {
+  it("serves HTML with frame-ancestors CSP and removes X-Frame-Options", async () => {
+    const r = mkRes();
+    r.res.setHeader("X-Frame-Options", "DENY");
+    const ctx = mkCtx("GET", "/api/apps/ratibot-research/viewer", mkRuntime(), r.res);
+    expect(await handleAppRoutes(ctx)).toBe(true);
+    expect(r.status).toBe(200);
+    expect(r.headers["content-type"]).toBe("text/html; charset=utf-8");
+    expect(r.headers["content-security-policy"]).toMatch(/frame-ancestors/);
+    expect(r.removed).toContain("x-frame-options");
+    expect(r.body).toContain("Ratibot Research");
+    expect(r.body).toContain("Kyro");
+  });
+
+  it("returns false on unknown paths", async () => {
+    const r = mkRes();
+    const ctx = mkCtx("GET", "/api/apps/ratibot-research/wat", mkRuntime(), r.res);
+    expect(await handleAppRoutes(ctx)).toBe(false);
+  });
+});
+
+describe("handleAppRoutes — proxies", () => {
+  it("GET /reports proxies the CDN", async () => {
+    mockGlobalFetch({});
+    const r = mkRes();
+    const ctx = mkCtx("GET", "/api/apps/ratibot-research/reports", mkRuntime(), r.res);
+    await handleAppRoutes(ctx);
+    expect(r.status).toBe(200);
+    const body = JSON.parse(r.body!);
+    expect(body.reports).toHaveLength(REPORTS.length);
+  });
+
+  it("GET /reports returns 502 on upstream failure", async () => {
+    mockGlobalFetch({ reports: "throw" });
+    const r = mkRes();
+    const ctx = mkCtx("GET", "/api/apps/ratibot-research/reports", mkRuntime(), r.res);
+    await handleAppRoutes(ctx);
+    expect(r.status).toBe(502);
+  });
+
+  it("GET /ecosystem prefers cached service when registered", async () => {
+    const fetchImpl = mockGlobalFetch({ ecosystem: "throw" });
+    const r = mkRes();
+    const ctx = mkCtx("GET", "/api/apps/ratibot-research/ecosystem", mkRuntime({ withEcosystemService: true }), r.res);
+    await handleAppRoutes(ctx);
+    expect(r.status).toBe(200);
+    const body = JSON.parse(r.body!);
+    expect(body.tokens[0].symbol).toBe("USDC");
+    // global fetch should NOT have been called for ecosystem — service has its own fetch
+    const fetchUrls = fetchImpl.mock.calls.map((c: any[]) => c[0]);
+    expect(fetchUrls.every((u: string) => !u.includes("ecosystem.json"))).toBe(true);
+  });
+});
+
+describe("handleAppRoutes — spotlight by mint", () => {
+  it("returns the matching spotlight entry", async () => {
+    mockGlobalFetch({});
+    const r = mkRes();
+    const ctx = mkCtx("GET", "/api/apps/ratibot-research/spotlight/USDC-ADDR", mkRuntime(), r.res);
+    await handleAppRoutes(ctx);
+    expect(r.status).toBe(200);
+    const body = JSON.parse(r.body!);
+    expect(body.found).toBe(true);
+    expect(body.symbol).toBe("USDC");
+    expect(body.href).toBe("https://cdn.test/reports/spotlight/2026-04-15-usdc.pdf");
+  });
+
+  it("404 when mint isn't in the ecosystem", async () => {
+    mockGlobalFetch({});
+    const r = mkRes();
+    const ctx = mkCtx("GET", "/api/apps/ratibot-research/spotlight/UNKNOWN", mkRuntime(), r.res);
+    await handleAppRoutes(ctx);
+    expect(r.status).toBe(404);
+    const body = JSON.parse(r.body!);
+    expect(body.found).toBe(false);
+  });
+
+  it("404 when the symbol resolves but no spotlight exists", async () => {
+    mockGlobalFetch({});
+    const r = mkRes();
+    const ctx = mkCtx("GET", "/api/apps/ratibot-research/spotlight/PENGU-ADDR", mkRuntime(), r.res);
+    await handleAppRoutes(ctx);
+    expect(r.status).toBe(404);
+    expect(JSON.parse(r.body!).symbol).toBe("PENGU");
+  });
+});
+
+describe("handleAppRoutes — session", () => {
+  it("GET /session/:id returns a running viewer state with telemetry", async () => {
+    mockGlobalFetch({});
+    const r = mkRes();
+    const ctx = mkCtx("GET", "/api/apps/ratibot-research/session/abc", mkRuntime(), r.res);
+    await handleAppRoutes(ctx);
+    expect(r.status).toBe(200);
+    const body = JSON.parse(r.body!);
+    expect(body.appName).toBe("@cenetex/plugin-ratibot-research");
+    expect(body.mode).toBe("viewer");
+    expect(body.status).toBe("running");
+    expect(body.telemetry.reportCount).toBe(REPORTS.length);
+    expect(body.telemetry.tokenCount).toBe(ECOSYSTEM.tokens.length);
+    expect(body.telemetry.homeToken).toBe(ECOSYSTEM.home_token);
+    expect(body.telemetry.topTokens).toHaveLength(2);
+  });
+
+  it("GET /session/:id returns degraded when both upstreams fail", async () => {
+    mockGlobalFetch({ reports: "throw", ecosystem: "throw" });
+    const r = mkRes();
+    const ctx = mkCtx("GET", "/api/apps/ratibot-research/session/abc", mkRuntime(), r.res);
+    await handleAppRoutes(ctx);
+    const body = JSON.parse(r.body!);
+    expect(body.status).toBe("degraded");
+  });
+
+  it("POST /session/:id/command echoes a suggestion and returns refreshed state", async () => {
+    mockGlobalFetch({});
+    const r = mkRes();
+    const ctx = mkCtx(
+      "POST",
+      "/api/apps/ratibot-research/session/abc/command",
+      mkRuntime(),
+      r.res,
+      { type: "suggestion", prompt: "Show latest weekly" },
+    );
+    await handleAppRoutes(ctx);
+    const body = JSON.parse(r.body!);
+    expect(body.success).toBe(true);
+    expect(body.message).toContain("Show latest weekly");
+    expect(body.session.status).toBe("running");
+  });
+});

--- a/src/actions/getSpotlight.ts
+++ b/src/actions/getSpotlight.ts
@@ -137,7 +137,7 @@ export const getSpotlightAction: Action = {
       const existing = await findSpotlightForMint(mint, apiBase);
       if (existing) {
         const text = `Spotlight available: ${existing.title}\n${apiBase}${existing.url}`;
-        callback?.({ text, action: "GET_SPOTLIGHT", data: existing });
+        callback?.({ text, action: "GET_SPOTLIGHT", data: { ...existing } });
         return { success: true, text, data: { ...existing } };
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,67 @@
 /**
  * @cenetex/plugin-ratibot-research
  *
- * Thin ElizaOS / Milady client for ratibot's published research. MVP surface:
+ * Eliza app + plugin for ratibot's published research. Surface:
  *   - subscribe to new reports as they are published (RatibotReportFeed)
+ *   - cached $RATI ecosystem rankings (RatibotEcosystem)
  *   - look up the spotlight PDF for a specific Solana token (GET_SPOTLIGHT)
+ *   - embedded viewer (reports list + ecosystem rankings) at
+ *     /api/apps/ratibot-research/viewer
  */
 
 import type { Plugin } from "@elizaos/core";
 
 import { getSpotlightAction } from "./actions/getSpotlight.js";
+import { RatibotEcosystem } from "./services/ratibot-ecosystem.js";
 import { RatibotReportFeed } from "./services/ratibot-feed.js";
+import {
+  collectLaunchDiagnostics,
+  handleAppRoutes,
+  refreshRunSession,
+  resolveLaunchSession,
+  type RouteContext,
+} from "./routes.js";
 
 export const ratibotResearchPlugin: Plugin = {
   name: "ratibot-research",
   description:
-    "Thin client for ratibot's Solana token research — subscribe to new reports and fetch deep dives on demand.",
+    "Thin client for ratibot's Solana token research — subscribe to new reports, browse ecosystem rankings, and fetch deep dives on demand.",
   actions: [getSpotlightAction],
-  services: [RatibotReportFeed],
+  services: [RatibotReportFeed, RatibotEcosystem],
+  app: {
+    displayName: "Ratibot Research",
+    category: "research",
+    launchType: "embed",
+    launchUrl: null,
+    capabilities: ["research", "solana", "feed", "ecosystem"],
+    runtimePlugin: "@cenetex/plugin-ratibot-research",
+    viewer: {
+      url: "/api/apps/ratibot-research/viewer",
+      sandbox: "allow-scripts allow-same-origin allow-popups allow-forms",
+    },
+    session: {
+      mode: "viewer",
+      features: ["commands", "telemetry"],
+    },
+  },
+  appBridge: {
+    handleAppRoutes: (ctx: unknown) => handleAppRoutes(ctx as RouteContext),
+    resolveLaunchSession,
+    refreshRunSession,
+    collectLaunchDiagnostics,
+  },
 };
 
 export default ratibotResearchPlugin;
 
 export { getSpotlightAction } from "./actions/getSpotlight.js";
 export { RatibotReportFeed } from "./services/ratibot-feed.js";
+export { RatibotEcosystem } from "./services/ratibot-ecosystem.js";
+export {
+  collectLaunchDiagnostics,
+  handleAppRoutes,
+  refreshRunSession,
+  resolveLaunchSession,
+} from "./routes.js";
+export { renderViewerHtml, VIEWER_FRAME_ANCESTORS_DIRECTIVE } from "./viewer.js";
 export type * from "./types.js";

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,424 @@
+import type {
+  IAgentRuntime,
+  PluginAppBridgeLaunchContext,
+  PluginAppBridgeRunContext,
+  PluginAppLaunchDiagnostic,
+  PluginAppSessionState,
+} from "@elizaos/core";
+
+import { RatibotReportFeed } from "./services/ratibot-feed.js";
+import { RatibotEcosystem } from "./services/ratibot-ecosystem.js";
+import type { EcosystemPayload, ReportIndexEntry } from "./types.js";
+import { renderViewerHtml, VIEWER_FRAME_ANCESTORS_DIRECTIVE } from "./viewer.js";
+
+const APP_NAME = "@cenetex/plugin-ratibot-research";
+const APP_DISPLAY_NAME = "Ratibot Research";
+const APP_ROUTE_PREFIX = "/api/apps/ratibot-research";
+const VIEWER_PATH = `${APP_ROUTE_PREFIX}/viewer`;
+const DEFAULT_CDN_BASE = "https://d1bn9lkpdxaeev.cloudfront.net";
+const FETCH_TIMEOUT_MS = 10_000;
+
+export interface RouteContext {
+  method: string;
+  pathname: string;
+  url?: URL;
+  runtime: unknown | null;
+  res: unknown;
+  error: (response: unknown, message: string, status?: number) => void;
+  json: (response: unknown, data: unknown, status?: number) => void;
+  readJsonBody: () => Promise<unknown>;
+}
+
+function getRuntime(value: unknown): IAgentRuntime | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as { getService?: unknown };
+  if (typeof candidate.getService !== "function") return null;
+  return candidate as unknown as IAgentRuntime;
+}
+
+function getCdnBase(runtime: IAgentRuntime | null): string {
+  const fromSetting =
+    typeof runtime?.getSetting === "function"
+      ? runtime.getSetting("RATIBOT_API_BASE")
+      : undefined;
+  const v =
+    typeof fromSetting === "string" && fromSetting.length > 0
+      ? fromSetting
+      : DEFAULT_CDN_BASE;
+  return v.replace(/\/$/, "");
+}
+
+function getCharacterName(runtime: IAgentRuntime | null): string {
+  const character = (runtime as { character?: { name?: string } } | null)?.character;
+  return character?.name ?? "Eliza Agent";
+}
+
+function getSessionId(runtime: IAgentRuntime | null): string {
+  const agentId = (runtime as { agentId?: string } | null)?.agentId;
+  return agentId ? `ratibot-research:${agentId}` : "ratibot-research:anonymous";
+}
+
+function tryGetEcosystem(runtime: IAgentRuntime | null): RatibotEcosystem | null {
+  if (!runtime) return null;
+  try {
+    return (
+      runtime.getService<RatibotEcosystem>(RatibotEcosystem.serviceType) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+function tryGetFeed(runtime: IAgentRuntime | null): RatibotReportFeed | null {
+  if (!runtime) return null;
+  try {
+    return (
+      runtime.getService<RatibotReportFeed>(RatibotReportFeed.serviceType) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function fetchJsonUpstream<T>(url: string): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status} from ${url}`);
+    const ct = res.headers.get("content-type") || "";
+    if (!ct.includes("application/json")) {
+      throw new Error(`${url}: not JSON (got ${ct || "no content-type"})`);
+    }
+    return (await res.json()) as T;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+interface ReportsCountByType {
+  spotlight: number;
+  weekly: number;
+  daily: number;
+  trade: number;
+}
+
+function countByType(reports: ReportIndexEntry[]): ReportsCountByType {
+  const counts: ReportsCountByType = { spotlight: 0, weekly: 0, daily: 0, trade: 0 };
+  for (const r of reports) {
+    if (r.type in counts) counts[r.type as keyof ReportsCountByType] += 1;
+  }
+  return counts;
+}
+
+function buildSessionState(args: {
+  runtime: IAgentRuntime | null;
+  reports: ReportIndexEntry[] | null;
+  ecosystem: EcosystemPayload | null;
+  status: "running" | "degraded";
+  summary: string;
+}): PluginAppSessionState {
+  const { runtime, reports, ecosystem, status, summary } = args;
+  const counts = countByType(reports ?? []);
+  const latest = reports?.[0];
+
+  const telemetry: Record<string, unknown> = {
+    cdnBase: getCdnBase(runtime),
+    reportCount: reports?.length ?? 0,
+    countsByType: { ...counts },
+  };
+  if (latest) {
+    telemetry.latestReport = {
+      type: latest.type,
+      title: latest.title,
+      url: latest.url,
+      date: latest.date,
+      generated_at: latest.generated_at,
+    };
+  }
+  if (ecosystem) {
+    telemetry.homeToken = ecosystem.home_token;
+    telemetry.homeHolders = ecosystem.home_holders;
+    telemetry.tokenCount = ecosystem.tokens.length;
+    telemetry.topTokens = ecosystem.tokens.slice(0, 5).map((t) => ({
+      rank: t.rank,
+      symbol: t.symbol,
+      price_usd: t.price_usd,
+      flow_direction: t.flow_direction,
+    }));
+  }
+
+  return {
+    sessionId: getSessionId(runtime),
+    appName: APP_NAME,
+    mode: "viewer",
+    status,
+    displayName: APP_DISPLAY_NAME,
+    agentId: (runtime as { agentId?: string } | null)?.agentId,
+    canSendCommands: true,
+    summary,
+    suggestedPrompts: [
+      "Show me the latest weekly report.",
+      "Find a spotlight for a Solana mint.",
+      "Refresh the ecosystem rankings.",
+    ],
+    telemetry: telemetry as PluginAppSessionState["telemetry"],
+  };
+}
+
+function sendHtmlResponse(res: unknown, html: string): void {
+  const response = res as {
+    end: (body?: string) => void;
+    setHeader: (name: string, value: string) => void;
+    statusCode: number;
+    removeHeader?: (name: string) => void;
+    getHeader?: (name: string) => number | string | string[] | undefined;
+  };
+  response.statusCode = 200;
+  response.setHeader("Cache-Control", "no-store");
+  response.setHeader("Content-Type", "text/html; charset=utf-8");
+  response.removeHeader?.("X-Frame-Options");
+  const existingCsp = response.getHeader?.("Content-Security-Policy");
+  const normalized =
+    typeof existingCsp === "string"
+      ? existingCsp.trim()
+      : Array.isArray(existingCsp)
+        ? existingCsp.join("; ").trim()
+        : "";
+  const nextCsp = /\bframe-ancestors\b/i.test(normalized)
+    ? normalized
+    : normalized.length > 0
+      ? `${normalized}; ${VIEWER_FRAME_ANCESTORS_DIRECTIVE}`
+      : VIEWER_FRAME_ANCESTORS_DIRECTIVE;
+  response.setHeader("Content-Security-Policy", nextCsp);
+  response.end(html);
+}
+
+function parseSessionId(pathname: string): string | null {
+  const m = pathname.match(/^\/api\/apps\/ratibot-research\/session\/([^/]+)(?:\/.*)?$/);
+  return m?.[1] ? decodeURIComponent(m[1]) : null;
+}
+
+function parseSessionSubroute(pathname: string): "command" | null {
+  return pathname.endsWith("/command") ? "command" : null;
+}
+
+async function loadSessionData(
+  runtime: IAgentRuntime | null,
+): Promise<{
+  reports: ReportIndexEntry[] | null;
+  ecosystem: EcosystemPayload | null;
+  status: "running" | "degraded";
+  summary: string;
+}> {
+  const cdnBase = getCdnBase(runtime);
+  const ecoService = tryGetEcosystem(runtime);
+
+  const reportsP = fetchJsonUpstream<{ reports?: ReportIndexEntry[] }>(
+    `${cdnBase}/reports/index.json`,
+  )
+    .then((p) => (Array.isArray(p.reports) ? p.reports : []))
+    .catch(() => null);
+
+  const ecoP = ecoService
+    ? ecoService.getEcosystem().catch(() => null)
+    : fetchJsonUpstream<EcosystemPayload>(`${cdnBase}/cache/ecosystem.json`).catch(
+        () => null,
+      );
+
+  const [reports, ecosystem] = await Promise.all([reportsP, ecoP]);
+
+  if (!reports && !ecosystem) {
+    return {
+      reports: null,
+      ecosystem: null,
+      status: "degraded",
+      summary: "Ratibot CDN unreachable. Check RATIBOT_API_BASE.",
+    };
+  }
+
+  const counts = countByType(reports ?? []);
+  const summaryParts = [
+    `${reports?.length ?? 0} reports`,
+    ecosystem
+      ? `${ecosystem.tokens.length} tokens · ${ecosystem.home_holders} $RATI holders`
+      : "ecosystem: unavailable",
+  ];
+  if (counts.spotlight) summaryParts.push(`${counts.spotlight} spotlights`);
+
+  return {
+    reports,
+    ecosystem,
+    status: "running",
+    summary: summaryParts.join(" · "),
+  };
+}
+
+export async function resolveLaunchSession(
+  ctx: PluginAppBridgeLaunchContext,
+): Promise<PluginAppSessionState | null> {
+  const runtime = getRuntime(ctx.runtime);
+  const { reports, ecosystem, status, summary } = await loadSessionData(runtime);
+  return buildSessionState({ runtime, reports, ecosystem, status, summary });
+}
+
+export async function refreshRunSession(
+  ctx: PluginAppBridgeRunContext,
+): Promise<PluginAppSessionState | null> {
+  return resolveLaunchSession(ctx);
+}
+
+export async function collectLaunchDiagnostics(
+  ctx: PluginAppBridgeRunContext,
+): Promise<PluginAppLaunchDiagnostic[]> {
+  const diagnostics: PluginAppLaunchDiagnostic[] = [];
+  if (ctx.session?.status === "degraded") {
+    diagnostics.push({
+      code: "ratibot-cdn-unreachable",
+      severity: "warning",
+      message:
+        ctx.session.summary ??
+        "Couldn't reach ratibot CDN. Reports and ecosystem data will be empty.",
+    });
+  }
+  return diagnostics;
+}
+
+export async function handleAppRoutes(ctx: RouteContext): Promise<boolean> {
+  const runtime = getRuntime(ctx.runtime);
+  const cdnBase = getCdnBase(runtime);
+
+  // Viewer
+  if (ctx.method === "GET" && ctx.pathname === VIEWER_PATH) {
+    sendHtmlResponse(
+      ctx.res,
+      renderViewerHtml({
+        agentName: getCharacterName(runtime),
+        sessionId: getSessionId(runtime),
+        apiBase: APP_ROUTE_PREFIX,
+        cdnBase,
+      }),
+    );
+    return true;
+  }
+
+  // Reports proxy
+  if (ctx.method === "GET" && ctx.pathname === `${APP_ROUTE_PREFIX}/reports`) {
+    try {
+      const body = await fetchJsonUpstream<unknown>(`${cdnBase}/reports/index.json`);
+      ctx.json(ctx.res, body);
+    } catch (err) {
+      ctx.error(
+        ctx.res,
+        err instanceof Error ? err.message : "reports fetch failed",
+        502,
+      );
+    }
+    return true;
+  }
+
+  // Ecosystem proxy (prefer cached service if available)
+  if (ctx.method === "GET" && ctx.pathname === `${APP_ROUTE_PREFIX}/ecosystem`) {
+    try {
+      const ecoService = tryGetEcosystem(runtime);
+      const body = ecoService
+        ? await ecoService.getEcosystem()
+        : await fetchJsonUpstream<unknown>(`${cdnBase}/cache/ecosystem.json`);
+      ctx.json(ctx.res, body);
+    } catch (err) {
+      ctx.error(
+        ctx.res,
+        err instanceof Error ? err.message : "ecosystem fetch failed",
+        502,
+      );
+    }
+    return true;
+  }
+
+  // Spotlight lookup by mint
+  const spotlightMatch = ctx.pathname.match(
+    /^\/api\/apps\/ratibot-research\/spotlight\/([^/]+)$/,
+  );
+  if (ctx.method === "GET" && spotlightMatch) {
+    const mint = decodeURIComponent(spotlightMatch[1]!);
+    try {
+      const [ecosystem, reportsPayload] = await Promise.all([
+        fetchJsonUpstream<{ tokens?: Array<{ address?: string; symbol?: string }> }>(
+          `${cdnBase}/cache/ecosystem.json`,
+        ),
+        fetchJsonUpstream<{ reports?: ReportIndexEntry[] }>(
+          `${cdnBase}/reports/index.json`,
+        ),
+      ]);
+      const symbol = ecosystem.tokens?.find((t) => t.address === mint)?.symbol?.trim();
+      if (!symbol) {
+        ctx.json(ctx.res, { found: false, reason: "mint not in ratibot ecosystem" }, 404);
+        return true;
+      }
+      const symbolLower = symbol.toLowerCase();
+      const entry = (reportsPayload.reports ?? []).find(
+        (r) => r.type === "spotlight" && r.url.toLowerCase().endsWith(`-${symbolLower}.pdf`),
+      );
+      if (!entry) {
+        ctx.json(
+          ctx.res,
+          { found: false, reason: "no spotlight published for this token yet", symbol },
+          404,
+        );
+        return true;
+      }
+      ctx.json(ctx.res, { found: true, symbol, report: { ...entry }, href: `${cdnBase}${entry.url}` });
+    } catch (err) {
+      ctx.error(
+        ctx.res,
+        err instanceof Error ? err.message : "spotlight lookup failed",
+        502,
+      );
+    }
+    return true;
+  }
+
+  // Session routes
+  const sessionId = parseSessionId(ctx.pathname);
+  if (!sessionId) return false;
+  const subroute = parseSessionSubroute(ctx.pathname);
+
+  if (ctx.method === "GET" && !subroute) {
+    const { reports, ecosystem, status, summary } = await loadSessionData(runtime);
+    ctx.json(ctx.res, buildSessionState({ runtime, reports, ecosystem, status, summary }));
+    return true;
+  }
+
+  if (ctx.method === "POST" && subroute === "command") {
+    const body = (await ctx.readJsonBody().catch(() => ({}))) as
+      | { type?: string; mint?: string; prompt?: string }
+      | null;
+
+    if (body?.type === "refresh") {
+      const ecoService = tryGetEcosystem(runtime);
+      if (ecoService) await ecoService.refresh().catch(() => undefined);
+      const feed = tryGetFeed(runtime);
+      if (feed) await feed.poll().catch(() => undefined);
+      const data = await loadSessionData(runtime);
+      ctx.json(ctx.res, {
+        success: true,
+        message: "Refreshed.",
+        session: buildSessionState({ runtime, ...data }),
+      });
+      return true;
+    }
+
+    const data = await loadSessionData(runtime);
+    ctx.json(ctx.res, {
+      success: true,
+      message: `Suggestion noted: ${body?.prompt ?? body?.type ?? "unknown"}`,
+      session: buildSessionState({ runtime, ...data }),
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/src/services/ratibot-ecosystem.ts
+++ b/src/services/ratibot-ecosystem.ts
@@ -1,0 +1,133 @@
+/**
+ * RatibotEcosystem — caches ratibot's `/cache/ecosystem.json` and exposes
+ * the parsed payload via `getEcosystem()`. Refreshes lazily (TTL) and on
+ * demand via `refresh()`. Read-only against the public CDN.
+ */
+
+import { Service, type IAgentRuntime } from "@elizaos/core";
+
+import type { EcosystemPayload } from "../types.js";
+
+export interface EcosystemServiceConfig {
+  apiBase?: string;
+  ttlMs?: number;
+  fetch?: typeof fetch;
+}
+
+const DEFAULT_API_BASE = "https://d1bn9lkpdxaeev.cloudfront.net";
+const DEFAULT_TTL_MS = 60_000;
+const FETCH_TIMEOUT_MS = 10_000;
+
+export class RatibotEcosystem extends Service {
+  static serviceType = "ratibot-ecosystem";
+  capabilityDescription =
+    "Cached snapshot of ratibot's $RATI ecosystem rankings (price, liquidity, flow direction).";
+
+  private apiBase: string;
+  private ttlMs: number;
+  private fetchImpl: typeof fetch;
+  private cache: { payload: EcosystemPayload; fetchedAt: number } | null = null;
+  private inflight: Promise<EcosystemPayload> | null = null;
+
+  constructor(runtime?: IAgentRuntime, config?: EcosystemServiceConfig) {
+    super(runtime);
+    const resolved = resolveConfig(runtime, config);
+    this.apiBase = resolved.apiBase;
+    this.ttlMs = resolved.ttlMs;
+    this.fetchImpl = resolved.fetch;
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<RatibotEcosystem> {
+    const svc = new RatibotEcosystem(runtime);
+    // best-effort prime; failures are non-fatal — getEcosystem() will retry
+    await svc.refresh().catch(() => undefined);
+    return svc;
+  }
+
+  async stop(): Promise<void> {
+    this.cache = null;
+    this.inflight = null;
+  }
+
+  async getEcosystem(): Promise<EcosystemPayload> {
+    const now = Date.now();
+    if (this.cache && now - this.cache.fetchedAt < this.ttlMs) {
+      return this.cache.payload;
+    }
+    return this.refresh();
+  }
+
+  /** Snapshot of the last successful fetch, or null if none. */
+  peek(): { payload: EcosystemPayload; fetchedAt: number } | null {
+    return this.cache;
+  }
+
+  async refresh(): Promise<EcosystemPayload> {
+    if (this.inflight) return this.inflight;
+    this.inflight = this.fetchEcosystem()
+      .then((payload) => {
+        this.cache = { payload, fetchedAt: Date.now() };
+        return payload;
+      })
+      .finally(() => {
+        this.inflight = null;
+      });
+    return this.inflight;
+  }
+
+  private async fetchEcosystem(): Promise<EcosystemPayload> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const res = await this.fetchImpl(`${this.apiBase}/cache/ecosystem.json`, {
+        signal: controller.signal,
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status} from ${this.apiBase}/cache/ecosystem.json`);
+      }
+      const ct = res.headers.get("content-type") || "";
+      if (!ct.includes("application/json")) {
+        throw new Error(`ecosystem.json not published yet (got ${ct || "no content-type"})`);
+      }
+      const payload = (await res.json()) as Partial<EcosystemPayload>;
+      return {
+        home_tokens: Array.isArray(payload.home_tokens) ? payload.home_tokens : [],
+        home_token: payload.home_token ?? "",
+        home_holders: typeof payload.home_holders === "number" ? payload.home_holders : 0,
+        scanned_at: payload.scanned_at ?? "",
+        cached_at: payload.cached_at ?? "",
+        tokens: Array.isArray(payload.tokens) ? payload.tokens : [],
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function resolveConfig(
+  runtime: IAgentRuntime | undefined,
+  override: EcosystemServiceConfig | undefined,
+): { apiBase: string; ttlMs: number; fetch: typeof fetch } {
+  const getString = (key: string): string | undefined => {
+    const v = runtime?.getSetting?.(key);
+    return typeof v === "string" && v.length > 0 ? v : undefined;
+  };
+  const apiBase = (
+    override?.apiBase ??
+    getString("RATIBOT_API_BASE") ??
+    DEFAULT_API_BASE
+  ).replace(/\/$/, "");
+  const ttlRaw = override?.ttlMs ?? getString("RATIBOT_ECOSYSTEM_TTL_MS");
+  const ttlMs =
+    typeof ttlRaw === "number"
+      ? ttlRaw
+      : ttlRaw
+        ? Math.max(5_000, Number(ttlRaw))
+        : DEFAULT_TTL_MS;
+  return {
+    apiBase,
+    ttlMs,
+    fetch: override?.fetch ?? globalThis.fetch.bind(globalThis),
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,28 @@ export interface ReportIndexEntry {
   size_bytes: number;
   generated_at: string;
 }
+
+/** One row of `/cache/ecosystem.json#tokens`. */
+export interface EcosystemToken {
+  address: string;
+  symbol: string;
+  name: string;
+  overlap_percent: number;
+  overlap_holders: number;
+  price_usd: number;
+  liquidity_usd: number;
+  flow_direction: "accumulating" | "new" | "distributing" | string;
+  flow_score: number;
+  rank: number;
+  source_tokens?: string[];
+  source_count?: number;
+}
+
+export interface EcosystemPayload {
+  home_tokens: string[];
+  home_token: string;
+  home_holders: number;
+  scanned_at: string;
+  cached_at: string;
+  tokens: EcosystemToken[];
+}

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1,0 +1,404 @@
+const VIEWER_FRAME_ANCESTORS_DIRECTIVE =
+  "frame-ancestors 'self' http://localhost:* http://127.0.0.1:* " +
+  "http://[::1]:* http://[0:0:0:0:0:0:0:1]:* https://localhost:* " +
+  "https://127.0.0.1:* https://[::1]:* https://[0:0:0:0:0:0:0:1]:* " +
+  "electrobun: capacitor: capacitor-electron: app: tauri: file:";
+
+export { VIEWER_FRAME_ANCESTORS_DIRECTIVE };
+
+export interface ViewerRenderOptions {
+  agentName: string;
+  sessionId: string;
+  apiBase: string;
+  cdnBase: string;
+}
+
+export function renderViewerHtml(opts: ViewerRenderOptions): string {
+  const safeAgent = escapeHtml(opts.agentName);
+  const safeSession = encodeURIComponent(opts.sessionId);
+  const safeApi = encodeURIComponent(opts.apiBase);
+  const safeCdn = encodeURIComponent(opts.cdnBase);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Ratibot Research — ${safeAgent}</title>
+<style>
+  :root {
+    color-scheme: dark;
+    --bg-0: #080706;
+    --bg-1: #110f0d;
+    --panel: rgba(18, 17, 14, 0.86);
+    --panel-border: rgba(245, 239, 223, 0.12);
+    --ink: #f5efdf;
+    --muted: #cfc3ad;
+    --faint: #8e846f;
+    --ore: #f1b566;
+    --signal: #80ffd5;
+    --up: #80ffd5;
+    --new: #f1b566;
+    --down: #ff8fa3;
+    --line: rgba(245, 239, 223, 0.08);
+  }
+  html, body {
+    margin: 0;
+    padding: 0;
+    background:
+      radial-gradient(circle at 16% 18%, rgba(241,181,102,0.12), transparent 30%),
+      radial-gradient(circle at 84% 80%, rgba(128,255,213,0.08), transparent 35%),
+      var(--bg-0);
+    color: var(--ink);
+    font-family: "IBM Plex Sans Condensed", "Arial Narrow", system-ui, -apple-system, sans-serif;
+    font-size: 13px;
+    line-height: 1.45;
+    min-height: 100vh;
+  }
+  header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--panel-border);
+    background: linear-gradient(180deg, rgba(241,181,102,0.06), transparent);
+  }
+  header .brand {
+    font-weight: 600;
+    font-size: 15px;
+    color: var(--ore);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  header .agent { color: var(--muted); font-size: 12px; }
+  header .home {
+    margin-left: auto;
+    font-family: "IBM Plex Mono", ui-monospace, monospace;
+    font-size: 11px;
+    color: var(--signal);
+  }
+  main {
+    display: grid;
+    grid-template-columns: minmax(280px, 1fr) minmax(320px, 1.4fr);
+    gap: 14px;
+    padding: 14px;
+  }
+  @media (max-width: 800px) {
+    main { grid-template-columns: 1fr; }
+  }
+  .panel {
+    background: var(--panel);
+    border: 1px solid var(--panel-border);
+    border-radius: 10px;
+    padding: 12px 14px;
+    min-height: 160px;
+  }
+  .panel h2 {
+    margin: 0 0 10px;
+    font-size: 11px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ore);
+    font-weight: 600;
+  }
+  .filters {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 10px;
+    flex-wrap: wrap;
+  }
+  .filters button {
+    border: 1px solid var(--panel-border);
+    background: rgba(241,181,102,0.05);
+    color: var(--muted);
+    padding: 3px 9px;
+    border-radius: 999px;
+    font: inherit;
+    font-size: 11px;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .filters button.active {
+    background: rgba(241,181,102,0.18);
+    color: var(--ore);
+    border-color: rgba(241,181,102,0.4);
+  }
+  ul.list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; max-height: 60vh; overflow-y: auto; }
+  ul.list li {
+    padding: 7px 10px;
+    border-radius: 6px;
+    background: rgba(245,239,223,0.03);
+    border: 1px solid var(--line);
+  }
+  ul.list li.empty { color: var(--faint); text-align: center; }
+  ul.list a {
+    color: var(--ink);
+    text-decoration: none;
+    display: block;
+  }
+  ul.list a:hover .title { color: var(--ore); }
+  .row-title { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
+  .badge {
+    font-family: "IBM Plex Mono", ui-monospace, monospace;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 1px 6px;
+    border-radius: 4px;
+    border: 1px solid var(--line);
+  }
+  .badge.spotlight { color: var(--signal); border-color: rgba(128,255,213,0.35); }
+  .badge.weekly { color: var(--ore); border-color: rgba(241,181,102,0.35); }
+  .badge.daily { color: var(--muted); }
+  .badge.trade { color: var(--down); border-color: rgba(255,143,163,0.35); }
+  .row-meta { color: var(--faint); font-size: 11px; margin-top: 2px; font-family: "IBM Plex Mono", ui-monospace, monospace; }
+  table.tokens {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+  }
+  table.tokens th {
+    text-align: left;
+    padding: 6px 8px;
+    color: var(--faint);
+    font-weight: 500;
+    text-transform: uppercase;
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    border-bottom: 1px solid var(--line);
+  }
+  table.tokens td {
+    padding: 7px 8px;
+    border-bottom: 1px solid var(--line);
+    font-variant-numeric: tabular-nums;
+  }
+  table.tokens td.num { text-align: right; font-family: "IBM Plex Mono", ui-monospace, monospace; }
+  table.tokens td.sym { font-weight: 600; color: var(--ore); }
+  table.tokens td.addr {
+    font-family: "IBM Plex Mono", ui-monospace, monospace;
+    color: var(--faint);
+    font-size: 10px;
+  }
+  table.tokens tr:hover td { background: rgba(241,181,102,0.04); }
+  .flow.accumulating { color: var(--up); }
+  .flow.new { color: var(--new); }
+  .flow.distributing { color: var(--down); }
+  .err-banner {
+    margin: 0 14px;
+    padding: 9px 12px;
+    border-radius: 6px;
+    background: rgba(255,143,163,0.08);
+    border: 1px solid rgba(255,143,163,0.3);
+    color: var(--down);
+    font-size: 12px;
+  }
+  footer {
+    padding: 10px 18px;
+    color: var(--faint);
+    font-size: 11px;
+    border-top: 1px solid var(--panel-border);
+    display: flex;
+    justify-content: space-between;
+  }
+  footer code { font-family: "IBM Plex Mono", ui-monospace, monospace; }
+</style>
+</head>
+<body>
+<header>
+  <span class="brand">Ratibot Research</span>
+  <span class="agent">· ${safeAgent}</span>
+  <span class="home" id="home-pill">$RATI</span>
+</header>
+<div id="err-banner" class="err-banner" hidden></div>
+<main>
+  <section class="panel">
+    <h2>Reports</h2>
+    <div class="filters" id="filters">
+      <button data-filter="all" class="active">All</button>
+      <button data-filter="spotlight">Spotlight</button>
+      <button data-filter="weekly">Weekly</button>
+      <button data-filter="daily">Daily</button>
+      <button data-filter="trade">Trade</button>
+    </div>
+    <ul class="list" id="reports-list"><li class="empty">Loading…</li></ul>
+  </section>
+  <section class="panel">
+    <h2>Ecosystem · top tokens by overlap</h2>
+    <table class="tokens">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Symbol</th>
+          <th class="num">Price</th>
+          <th class="num">Liquidity</th>
+          <th>Flow</th>
+          <th class="num">Overlap</th>
+        </tr>
+      </thead>
+      <tbody id="tokens-body"><tr><td colspan="6" style="color:var(--faint);text-align:center;padding:14px">Loading…</td></tr></tbody>
+    </table>
+  </section>
+</main>
+<footer>
+  <span>session <code id="session-id">${escapeHtml(opts.sessionId)}</code></span>
+  <span id="last-updated">—</span>
+</footer>
+<script type="module">
+  const SESSION_ID = decodeURIComponent("${safeSession}");
+  const API_BASE = decodeURIComponent("${safeApi}");
+  const CDN_BASE = decodeURIComponent("${safeCdn}");
+
+  const el = (id) => document.getElementById(id);
+  const banner = el("err-banner");
+  const reportsList = el("reports-list");
+  const tokensBody = el("tokens-body");
+  const lastUpdated = el("last-updated");
+  const homePill = el("home-pill");
+  const filters = el("filters");
+
+  let activeFilter = "all";
+  let allReports = [];
+
+  function showError(msg) { banner.textContent = msg; banner.hidden = false; }
+  function clearError() { banner.hidden = true; }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]);
+  }
+
+  function fmtBytes(n) {
+    if (!n) return '';
+    if (n < 1024) return n + ' B';
+    if (n < 1024 * 1024) return (n / 1024).toFixed(1) + ' KB';
+    return (n / 1024 / 1024).toFixed(1) + ' MB';
+  }
+
+  function fmtUsd(n) {
+    if (!Number.isFinite(n) || n === 0) return '—';
+    if (n >= 1_000_000) return '$' + (n / 1_000_000).toFixed(2) + 'M';
+    if (n >= 1_000) return '$' + (n / 1_000).toFixed(1) + 'K';
+    if (n >= 1) return '$' + n.toFixed(2);
+    if (n >= 0.01) return '$' + n.toFixed(4);
+    return '$' + n.toExponential(2);
+  }
+
+  function shortAddr(a) {
+    if (!a || a.length < 10) return a || '';
+    return a.slice(0, 4) + '…' + a.slice(-4);
+  }
+
+  function renderReports() {
+    const list = activeFilter === 'all'
+      ? allReports
+      : allReports.filter((r) => r.type === activeFilter);
+    if (list.length === 0) {
+      reportsList.innerHTML = '<li class="empty">No reports of this type yet.</li>';
+      return;
+    }
+    reportsList.innerHTML = list.map((r) => {
+      const href = CDN_BASE + r.url;
+      const safeTitle = escapeHtml(r.title || '(untitled)');
+      const date = escapeHtml(r.date || '');
+      const size = fmtBytes(r.size_bytes);
+      return '<li><a target="_blank" rel="noopener" href="' + href + '">' +
+        '<div class="row-title">' +
+          '<span class="badge ' + r.type + '">' + r.type + '</span>' +
+          '<span class="title">' + safeTitle + '</span>' +
+        '</div>' +
+        '<div class="row-meta">' + date + (size ? ' · ' + size : '') + '</div>' +
+      '</a></li>';
+    }).join('');
+  }
+
+  function renderTokens(payload) {
+    const tokens = Array.isArray(payload?.tokens) ? payload.tokens : [];
+    if (tokens.length === 0) {
+      tokensBody.innerHTML = '<tr><td colspan="6" style="color:var(--faint);text-align:center;padding:14px">No tokens.</td></tr>';
+      return;
+    }
+    tokensBody.innerHTML = tokens.slice(0, 20).map((t) => {
+      const flow = String(t.flow_direction || '').toLowerCase();
+      const overlap = (typeof t.overlap_percent === 'number' ? t.overlap_percent.toFixed(1) : '—') + '%';
+      return '<tr>' +
+        '<td class="num">' + (t.rank ?? '—') + '</td>' +
+        '<td class="sym">' + escapeHtml(t.symbol || '') + '<div class="addr">' + escapeHtml(shortAddr(t.address)) + '</div></td>' +
+        '<td class="num">' + fmtUsd(t.price_usd) + '</td>' +
+        '<td class="num">' + fmtUsd(t.liquidity_usd) + '</td>' +
+        '<td class="flow ' + flow + '">' + escapeHtml(flow || '—') + '</td>' +
+        '<td class="num">' + overlap + '</td>' +
+      '</tr>';
+    }).join('');
+    if (payload?.home_token) {
+      homePill.textContent = '$RATI · ' + (payload.home_holders ?? '?') + ' holders · ' + shortAddr(payload.home_token);
+    }
+  }
+
+  async function refreshAll() {
+    try {
+      const [reportsRes, ecoRes, sessRes] = await Promise.all([
+        fetch(API_BASE + '/reports', { headers: { accept: 'application/json' } }),
+        fetch(API_BASE + '/ecosystem', { headers: { accept: 'application/json' } }),
+        fetch(API_BASE + '/session/' + encodeURIComponent(SESSION_ID), { headers: { accept: 'application/json' } }),
+      ]);
+      if (!reportsRes.ok) throw new Error('reports HTTP ' + reportsRes.status);
+      const reportsBody = await reportsRes.json();
+      allReports = Array.isArray(reportsBody?.reports) ? reportsBody.reports : [];
+      renderReports();
+
+      if (ecoRes.ok) {
+        const eco = await ecoRes.json();
+        renderTokens(eco);
+      }
+
+      if (sessRes.ok) {
+        const sess = await sessRes.json();
+        if (sess?.summary) {
+          lastUpdated.textContent = sess.summary;
+        }
+      } else {
+        lastUpdated.textContent = 'updated ' + new Date().toLocaleTimeString();
+      }
+      clearError();
+    } catch (err) {
+      showError(err && err.message ? err.message : String(err));
+    }
+  }
+
+  filters.addEventListener('click', (ev) => {
+    const t = ev.target;
+    if (!(t instanceof HTMLButtonElement)) return;
+    const f = t.dataset.filter;
+    if (!f) return;
+    activeFilter = f;
+    for (const b of filters.querySelectorAll('button')) {
+      b.classList.toggle('active', b.dataset.filter === activeFilter);
+    }
+    renderReports();
+  });
+
+  refreshAll();
+  setInterval(refreshAll, 30000);
+</script>
+</body>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (c) => {
+    switch (c) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return c;
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Adds the Eliza **app** envelope to `@cenetex/plugin-ratibot-research` per the abstraction in [`elizaOS/eliza/apps`](https://github.com/elizaOS/eliza/tree/develop/apps) (develop). Bumps `@elizaos/core` to `2.0.0-alpha.173` (matches sector-one — adds `Plugin.app` + `Plugin.appBridge` typings).

- `package.json` → `elizaos.kind: "app"` manifest, core bump
- `src/services/ratibot-ecosystem.ts` (new) → `RatibotEcosystem` service caches `/cache/ecosystem.json` with TTL + collapses concurrent refreshes
- `src/index.ts` → Plugin sets `app` (manifest) + `appBridge` (route + lifecycle handlers); registers the ecosystem service
- `src/routes.ts` → mounts `/api/apps/ratibot-research/*` (viewer, reports proxy, ecosystem proxy, spotlight-by-mint, session, command)
- `src/viewer.ts` → self-contained two-pane HTML console: filterable reports list + ecosystem rankings table (rank, symbol, price, liquidity, flow, overlap %); 30s auto-refresh
- `src/types.ts` → `EcosystemPayload` + `EcosystemToken` wire types
- `src/actions/getSpotlight.ts` → spread-fix for tightened `ActionResult.data` typing in core 2.x
- 16 new tests (5 ecosystem service, 11 routes)

Backwards compatible: `ratibotResearchPlugin` exports unchanged for hosts that don't read `app`/`appBridge`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 42/42 (4 baseline + 5 ecosystem + 11 routes + 22 prior)
- [x] `npm run build` clean (tsc)
- [x] **Smoke-tested against the real CDN** (`d1bn9lkpdxaeev.cloudfront.net`) — viewer renders 3 weekly reports + 10 ranked tokens with `$RATI` as home_token (674 holders); ecosystem proxy + reports proxy both 200; session telemetry includes `topTokens`, `latestReport`, `homeHolders`
- [ ] Load into an Eliza runtime that supports `app`/`appBridge` and verify the Ratibot Research card renders + the embedded viewer iframe loads
- [ ] Confirm `GET_SPOTLIGHT` action still works alongside the new app routes (no regressions)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)