### PR TITLE
Rename package to @cenetex/app-ratibot-research (Milady apps-browser convention)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @cenetex/plugin-ratibot-research
+# @cenetex/app-ratibot-research
 
 Thin ElizaOS / Milady client for [ratibot](https://github.com/cenetex/ratibot)'s
 published Solana token research.
@@ -15,7 +15,7 @@ so existing reports aren't replayed; only reports that appear in subsequent
 polls fire events.
 
 ```ts
-import { RatibotReportFeed } from "@cenetex/plugin-ratibot-research";
+import { RatibotReportFeed } from "@cenetex/app-ratibot-research";
 
 const feed = runtime.getService<RatibotReportFeed>(RatibotReportFeed.serviceType);
 feed?.onReport((entry) => {
@@ -36,11 +36,11 @@ fetch the published spotlight PDF for that token.
 ## Install
 
 ```bash
-npm install @cenetex/plugin-ratibot-research
+npm install @cenetex/app-ratibot-research
 ```
 
 ```ts
-import { ratibotResearchPlugin } from "@cenetex/plugin-ratibot-research";
+import { ratibotResearchPlugin } from "@cenetex/app-ratibot-research";
 
 export default {
   plugins: [ratibotResearchPlugin],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@cenetex/plugin-ratibot-research",
-  "version": "0.0.1",
+  "name": "@cenetex/app-ratibot-research",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cenetex/plugin-ratibot-research",
-      "version": "0.0.1",
+      "name": "@cenetex/app-ratibot-research",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@elizaos/core": "^2.0.0-alpha.173"
@@ -348,226 +348,6 @@
         "@langchain/core": "^1.0.0"
       }
     },
-    "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.99.tgz",
-      "integrity": "sha512-9OCRt8VVxA17m32NWZKyNC2qamdaS/SC5CEOIQwFngRq0DIeVm4PDal+6Ljnhqm2whZiC63DNuKZ4xSp2nbj9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.99.tgz",
-      "integrity": "sha512-lupMDMy1+H38dhyCcLirOKKVUyzzlxi7j7rGPLI3vViMHOoPjcXO1b10ivy+ad+q6MiwHfoLjKTCoLke5ySOBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.99.tgz",
-      "integrity": "sha512-fdz02t4w8n6Ii/rYhWig6STb/zcTmCC/6YZTGmjoDeidDwn9Wf0ukQVynhCPEs29vqUc66wHZKsuIgMs9tycCg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.99.tgz",
-      "integrity": "sha512-w4FwVwlNo00ezeRhfY62IVIyt6G3u8wodkPtiqWc52BUHx+VDBUM2vkS3ogfANaLI7hnf3s6WK4LyZVUjBg1lA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.99.tgz",
-      "integrity": "sha512-8JvHeexKQ8c7g0q7YJ29NVQwnf1ePghP9ys9ZN0R0qzyqJQ9Uw6N9qnDINArlm3IYHexB7LjzArIfhQiqSDGvQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.99.tgz",
-      "integrity": "sha512-Z+6nyLdJXWzLPVxi4H6g9TJop4DwN3KSgHWto5JCbZV5/uKoVqcSynPs0tGlUHOoWI8S8tEvJspz51GQkvr07w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.99.tgz",
-      "integrity": "sha512-jAnfOUv4IO1l8Levk5t85oVtEBOXLa07KnIUgWo1CDlPxiqpxS3uBfiE38Lvj/CQgHaNF6Nxk/SaemwLgsVJgw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.99.tgz",
-      "integrity": "sha512-mIkXw3fGmbYyFjSmfWEvty4jN+rwEOmv0+Dy9bRvvTzLYWCgm3RMgUEQVfAKFw96nIRFnyNZiK83KNQaVVFjng==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.99.tgz",
-      "integrity": "sha512-f3Uz2P0RgrtBHISxZqr6yiYXJlTDyCVBumDacxo+4AmSg7z0HiqYZKGWC/gszq3fbPhyQUya1W2AEteKxT9Y6A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.99.tgz",
-      "integrity": "sha512-XE6KUkfqRsCNejcoRMiMr3RaUeObxNf6y7dut3hrq2rn7PzfRTZgrjF1F/B2C7FcdgqY/vSHWpQeMuNz1vTNHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.99.tgz",
-      "integrity": "sha512-plMYGVbc/vmmPF9MtmHbwNk1rL1Aj53vQZt+Gnv1oZn6gmd9jEHHJ0n9Nd2nxa5sKH7TS5IjkCDM6289O0d6PQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -892,6 +672,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@cenetex/plugin-ratibot-research",
-  "version": "0.0.1",
+  "name": "@cenetex/app-ratibot-research",
+  "version": "0.1.0",
   "description": "Thin ElizaOS / Milady client for ratibot's published Solana token research — fetches spotlight reports on demand.",
   "type": "module",
   "main": "./dist/index.js",
@@ -46,7 +46,7 @@
         "feed",
         "ecosystem"
       ],
-      "runtimePlugin": "@cenetex/plugin-ratibot-research",
+      "runtimePlugin": "@cenetex/app-ratibot-research",
       "viewer": {
         "url": "/api/apps/ratibot-research/viewer",
         "sandbox": "allow-scripts allow-same-origin allow-popups allow-forms"

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,47 @@
+// Live smoke test against ratibot's production CDN.
+// Run with: node scripts/smoke.mjs
+// Exercises both MVP capabilities — subscription feed + spotlight lookup.
+
+import { getSpotlightAction, RatibotReportFeed } from "../dist/index.js";
+
+const API_BASE = process.env.RATIBOT_API_BASE || "https://d1bn9lkpdxaeev.cloudfront.net";
+
+const runtime = {
+  getSetting: (k) => (k === "RATIBOT_API_BASE" ? API_BASE : null),
+  getService: () => null,
+};
+
+async function main() {
+  console.log(`\n== feed: pulling /reports/index.json from ${API_BASE} ==`);
+  const feed = new RatibotReportFeed(undefined, { apiBase: API_BASE });
+  // First poll establishes the baseline.
+  await feed.poll();
+  const baseline = [...feed["seen"]];
+  console.log(`  baseline: ${baseline.length} reports already published`);
+  baseline.slice(0, 5).forEach((u) => console.log(`    - ${u}`));
+  if (baseline.length > 5) console.log(`    ... and ${baseline.length - 5} more`);
+
+  console.log(`\n== ecosystem: resolving a mint via /cache/ecosystem.json ==`);
+  const res = await fetch(`${API_BASE}/cache/ecosystem.json`);
+  const eco = await res.json();
+  const tokens = Array.isArray(eco.tokens) ? eco.tokens : [];
+  console.log(`  ${tokens.length} tokens in ecosystem`);
+  const probe = tokens.find((t) => t.symbol && t.address) ?? tokens[0];
+  if (!probe) {
+    console.log("  ecosystem empty — can't probe spotlight");
+    return;
+  }
+  console.log(`  probe token: ${probe.symbol} (${probe.address})`);
+
+  console.log(`\n== action: GET_SPOTLIGHT on that mint ==`);
+  const message = { content: { text: `Tell me about ${probe.address}` } };
+  const out = await getSpotlightAction.handler(runtime, message);
+  console.log(`  success: ${out?.success}`);
+  console.log(`  text: ${out?.text}`);
+  if (out?.data?.url) console.log(`  url: ${API_BASE}${out.data.url}`);
+}
+
+main().catch((err) => {
+  console.error("smoke failed:", err);
+  process.exit(1);
+});

--- a/src/__tests__/routes.test.ts
+++ b/src/__tests__/routes.test.ts
@@ -253,7 +253,7 @@ describe("handleAppRoutes — session", () => {
     await handleAppRoutes(ctx);
     expect(r.status).toBe(200);
     const body = JSON.parse(r.body!);
-    expect(body.appName).toBe("@cenetex/plugin-ratibot-research");
+    expect(body.appName).toBe("@cenetex/app-ratibot-research");
     expect(body.mode).toBe("viewer");
     expect(body.status).toBe("running");
     expect(body.telemetry.reportCount).toBe(REPORTS.length);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @cenetex/plugin-ratibot-research
+ * @cenetex/app-ratibot-research
  *
  * Eliza app + plugin for ratibot's published research. Surface:
  *   - subscribe to new reports as they are published (RatibotReportFeed)
@@ -34,7 +34,7 @@ export const ratibotResearchPlugin: Plugin = {
     launchType: "embed",
     launchUrl: null,
     capabilities: ["research", "solana", "feed", "ecosystem"],
-    runtimePlugin: "@cenetex/plugin-ratibot-research",
+    runtimePlugin: "@cenetex/app-ratibot-research",
     viewer: {
       url: "/api/apps/ratibot-research/viewer",
       sandbox: "allow-scripts allow-same-origin allow-popups allow-forms",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -11,7 +11,7 @@ import { RatibotEcosystem } from "./services/ratibot-ecosystem.js";
 import type { EcosystemPayload, ReportIndexEntry } from "./types.js";
 import { renderViewerHtml, VIEWER_FRAME_ANCESTORS_DIRECTIVE } from "./viewer.js";
 
-const APP_NAME = "@cenetex/plugin-ratibot-research";
+const APP_NAME = "@cenetex/app-ratibot-research";
 const APP_DISPLAY_NAME = "Ratibot Research";
 const APP_ROUTE_PREFIX = "/api/apps/ratibot-research";
 const VIEWER_PATH = `${APP_ROUTE_PREFIX}/viewer`;


### PR DESCRIPTION
## Summary

Renames the npm package from `@cenetex/plugin-ratibot-research` → `@cenetex/app-ratibot-research` to match the `app-` prefix convention used by all curated Eliza apps. Milady's dashboard apps browser filters by this prefix; without it the app may not appear in the catalog UI.

- `package.json`: name + `elizaos.app.runtimePlugin`; version 0.0.1 → 0.1.0 (rename = breaking)
- `src/index.ts`: header doc comment + `Plugin.app.runtimePlugin`
- `src/routes.ts`: `APP_NAME` constant
- `src/__tests__/routes.test.ts`: `appName` assertion
- `README.md`: heading, install line, import examples
- `package-lock.json`: regenerated

This PR also drags in `scripts/smoke.mjs` — a pre-existing live-CDN smoke harness that was untracked. It still works (imports from `../dist/index.js`, name-agnostic). Trivial side-bring.

GitHub repository name (`cenetex/plugin-ratibot-research`) intentionally unchanged.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 29/29 unique (vitest also picks up duplicates from `dist/` due to a pre-existing config issue; fix is out of scope here)
- [x] `npm run build` clean
- [x] grep confirms no remaining `@cenetex/plugin-ratibot-research` references in tracked source